### PR TITLE
feat(terraform): add tagging for private and public subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Truefoundry AWS Network Module
 
 | Name | Type |
 |------|------|
+| [aws_ec2_tag.private_subnet_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_tag) | resource |
+| [aws_ec2_tag.public_subnet_tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_tag) | resource |
 | [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_iam_policy_document.flow_logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_subnet.private_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |

--- a/locals.tf
+++ b/locals.tf
@@ -3,6 +3,7 @@ locals {
 
   flow_logs_bucket_arn = var.flow_logs_enable ? module.vpc_flow_logs_bucket[0].s3_bucket_arn : null
 
+  # Base tags for all resources
   tags = merge(
     {
       "terraform-module" = "network"
@@ -11,4 +12,40 @@ locals {
     },
     var.tags
   )
+
+  # Define base tags that match the VPC module's tags
+  private_subnet_base_tags = merge(
+    {
+      "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+      "kubernetes.io/role/internal-elb"           = "1"
+      "subnet"                                    = "private"
+    },
+    var.private_subnet_extra_tags,
+    local.tags
+  )
+
+  public_subnet_base_tags = merge(
+    {
+      "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+      "kubernetes.io/role/elb"                    = "1"
+      "subnet"                                    = "public"
+    },
+    var.public_subnet_extra_tags,
+    local.tags
+  )
+
+  # Convert all tags to list format for aws_ec2_tag resources
+  private_subnet_tags_list = [
+    for k, v in local.private_subnet_base_tags : {
+      key   = k
+      value = v
+    }
+  ]
+
+  public_subnet_tags_list = [
+    for k, v in local.public_subnet_base_tags : {
+      key   = k
+      value = v
+    }
+  ]
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,5 +1,5 @@
 module "aws-vpc-module" {
-  count   = var.shim == true ? 0 : 1
+  count   = var.shim ? 0 : 1
   source  = "terraform-aws-modules/vpc/aws"
   version = "5.0.0"
 
@@ -67,4 +67,20 @@ data "aws_subnet" "public_subnets" {
   count = var.shim ? length(var.public_subnets_ids) : 0
 
   id = element(var.public_subnets_ids, count.index)
+}
+
+resource "aws_ec2_tag" "private_subnet_tags" {
+  count = var.shim ? length(var.private_subnets_ids) * length(local.private_subnet_tags_list) : 0
+
+  resource_id = var.private_subnets_ids[floor(count.index / length(local.private_subnet_tags_list))]
+  key         = local.private_subnet_tags_list[count.index % length(local.private_subnet_tags_list)].key
+  value       = local.private_subnet_tags_list[count.index % length(local.private_subnet_tags_list)].value
+}
+
+resource "aws_ec2_tag" "public_subnet_tags" {
+  count = var.shim ? length(var.public_subnets_ids) * length(local.public_subnet_tags_list) : 0
+
+  resource_id = var.public_subnets_ids[floor(count.index / length(local.public_subnet_tags_list))]
+  key         = local.public_subnet_tags_list[count.index % length(local.public_subnet_tags_list)].key
+  value       = local.public_subnet_tags_list[count.index % length(local.public_subnet_tags_list)].value
 }


### PR DESCRIPTION
Introduce base tags for private and public subnets to ensure
consistency with VPC module tags. Convert tags to list format
for aws_ec2_tag resources to facilitate tagging. Simplify
conditional logic for module count.
