### PR TITLE
feat(network): add subnet tag validation for shim mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # terraform-aws-truefoundry-network
+
 Truefoundry AWS Network Module
 
 <!-- BEGIN_TF_DOCS -->
@@ -71,3 +72,25 @@ Truefoundry AWS Network Module
 | <a name="output_region"></a> [region](#output\_region) | AWS region of VPC |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | VPC ID of the network |
 <!-- END_TF_DOCS -->
+## Subnet Tag Validation (Shim Mode)
+
+When using the module in shim mode (with existing subnets), the following outputs are available:
+
+- `private_subnets_tags`: List of tag maps for each private subnet
+- `public_subnets_tags`: List of tag maps for each public subnet
+
+You should check these outputs to ensure your subnets have the required tags:
+
+**Private Subnets:**
+
+- `kubernetes.io/cluster/$CLUSTER_NAME`: "shared"
+- `subnet`: "private"
+- `kubernetes.io/role/internal-elb`: "1"
+
+**Public Subnets:**
+
+- `kubernetes.io/cluster/$CLUSTER_NAME`: "shared"
+- `subnet`: "public"
+- `kubernetes.io/role/elb`: "1"
+
+If any subnet is missing these tags, you must add them manually in the AWS console or via CLI.

--- a/locals.tf
+++ b/locals.tf
@@ -11,4 +11,30 @@ locals {
     },
     var.tags
   )
+  required_private_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "subnet"                                    = "private"
+    "kubernetes.io/role/internal-elb"           = "1"
+  }
+  required_public_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "subnet"                                    = "public"
+    "kubernetes.io/role/elb"                    = "1"
+  }
+
+  private_subnets_missing_tags = var.shim ? [
+    for i, s in data.aws_subnet.private_subnets : {
+      id      = s.id
+      missing = [for k, v in local.required_private_tags : k if lookup(s.tags, k, null) != v]
+    } if length([for k, v in local.required_private_tags : k if lookup(s.tags, k, null) != v]) > 0
+  ] : []
+
+  public_subnets_missing_tags = var.shim ? [
+    for i, s in data.aws_subnet.public_subnets : {
+      id      = s.id
+      missing = [for k, v in local.required_public_tags : k if lookup(s.tags, k, null) != v]
+    } if length([for k, v in local.required_public_tags : k if lookup(s.tags, k, null) != v]) > 0
+  ] : []
+
+
 }

--- a/output.tf
+++ b/output.tf
@@ -34,3 +34,37 @@ output "availability_zones" {
   description = "List of availability zones for VPC"
   value       = var.azs
 }
+
+output "validate_private_subnet_tags" {
+  value = local.private_subnets_missing_tags
+  precondition {
+    condition     = length(local.private_subnets_missing_tags) == 0
+    error_message = <<EOT
+Some private subnets are missing required tags: ${jsonencode(local.private_subnets_missing_tags)}
+
+Required tags for private subnets:
+- "kubernetes.io/cluster/${var.cluster_name}": "shared"
+- "subnet": "private"
+- "kubernetes.io/role/internal-elb": "1"
+
+See: https://docs.truefoundry.com/docs/requirements#vpc-tags
+EOT
+  }
+}
+
+output "validate_public_subnet_tags" {
+  value = local.public_subnets_missing_tags
+  precondition {
+    condition     = length(local.public_subnets_missing_tags) == 0
+    error_message = <<EOT
+Some public subnets are missing required tags: ${jsonencode(local.public_subnets_missing_tags)}
+
+Required tags for public subnets:
+- "kubernetes.io/cluster/${var.cluster_name}": "shared"
+- "subnet": "public"
+- "kubernetes.io/role/elb": "1"
+
+See: https://docs.truefoundry.com/docs/requirements#vpc-tags
+EOT
+  }
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -56,3 +56,7 @@ resource "aws_vpc_endpoint" "s3" {
   service_name = "com.amazonaws.${var.aws_region}.s3"
   tags         = local.tags
 }
+
+variable "_validate_subnet_tags" {
+  default = true
+}


### PR DESCRIPTION
Introduce validation for subnet tags when using shim mode with existing
subnets. This ensures that both private and public subnets have the
required tags for Kubernetes integration. Outputs are added to check
missing tags, and preconditions are set to enforce tag presence. This
enhancement aids in maintaining correct subnet configurations and
prevents potential issues with Kubernetes operations.
