### PR TITLE
feat: add support for EKS custom networking with secondary CIDR …

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Truefoundry AWS Network Module
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | VPC region | `string` | n/a | yes |
 | <a name="input_azs"></a> [azs](#input\_azs) | Availability Zones | `list(string)` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | AWS EKS cluster name needed for Shared cluster | `string` | `""` | no |
-| <a name="input_eks_pod_secondary_subnet_cidrs"></a> [eks\_pod\_secondary\_subnet\_cidrs](#input\_eks\_pod\_secondary\_subnet\_cidrs) | List of CIDR blocks for EKS pod subnets (one per AZ) from the secondary CIDR | `list(string)` | `[]` | no |
+| <a name="input_custom_networking_subnet_cidrs"></a> [custom\_networking\_subnet\_cidrs](#input\_custom\_networking\_subnet\_cidrs) | List of CIDR blocks for EKS custom networking subnets (one per AZ) from the secondary CIDR | `list(string)` | `[]` | no |
+| <a name="input_custom_networking_subnet_ids"></a> [custom\_networking\_subnet\_ids](#input\_custom\_networking\_subnet\_ids) | SHIM: Pre-existing pod subnet IDs for EKS custom networking | `list(string)` | `[]` | no |
+| <a name="input_enable_custom_networking"></a> [enable\_custom\_networking](#input\_enable\_custom\_networking) | Enable custom networking | `bool` | `false` | no |
 | <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | Enable NAT Gateway - This is necessary for the cluster to work | `bool` | `true` | no |
 | <a name="input_external_nat_ip_ids"></a> [external\_nat\_ip\_ids](#input\_external\_nat\_ip\_ids) | External NAT IPs IDs | `list(string)` | `[]` | no |
 | <a name="input_flow_logs_bucket_attach_deny_insecure_transport_policy"></a> [flow\_logs\_bucket\_attach\_deny\_insecure\_transport\_policy](#input\_flow\_logs\_bucket\_attach\_deny\_insecure\_transport\_policy) | Flag to attach deny insecure transport policy to the bucket | `bool` | `true` | no |
@@ -60,14 +62,13 @@ Truefoundry AWS Network Module
 | <a name="input_flow_logs_bucket_restrict_public_buckets"></a> [flow\_logs\_bucket\_restrict\_public\_buckets](#input\_flow\_logs\_bucket\_restrict\_public\_buckets) | Flag to restrict public buckets on the bucket | `bool` | `true` | no |
 | <a name="input_flow_logs_enable"></a> [flow\_logs\_enable](#input\_flow\_logs\_enable) | Enable VPC flow logs | `bool` | `false` | no |
 | <a name="input_one_nat_gateway_per_az"></a> [one\_nat\_gateway\_per\_az](#input\_one\_nat\_gateway\_per\_az) | One NAT Gateway for each AZ. | `bool` | `false` | no |
-| <a name="input_pod_subnets_ids"></a> [pod\_subnets\_ids](#input\_pod\_subnets\_ids) | SHIM: Pre-existing pod subnet IDs for EKS custom networking | `list(string)` | `[]` | no |
 | <a name="input_private_subnet_extra_tags"></a> [private\_subnet\_extra\_tags](#input\_private\_subnet\_extra\_tags) | Extra tags for VPC private subnets | `map(string)` | `{}` | no |
 | <a name="input_private_subnets_cidrs"></a> [private\_subnets\_cidrs](#input\_private\_subnets\_cidrs) | Assigns IPv4 private subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | <a name="input_private_subnets_ids"></a> [private\_subnets\_ids](#input\_private\_subnets\_ids) | SHIM: Private Subnets IDs | `list(string)` | `[]` | no |
 | <a name="input_public_subnet_extra_tags"></a> [public\_subnet\_extra\_tags](#input\_public\_subnet\_extra\_tags) | Extra tags for VPC public subnets | `map(string)` | `{}` | no |
 | <a name="input_public_subnets_cidrs"></a> [public\_subnets\_cidrs](#input\_public\_subnets\_cidrs) | Assigns IPv4 public subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | <a name="input_public_subnets_ids"></a> [public\_subnets\_ids](#input\_public\_subnets\_ids) | SHIM: Public Subnets IDs | `list(string)` | `[]` | no |
-| <a name="input_secondary_cidr_block"></a> [secondary\_cidr\_block](#input\_secondary\_cidr\_block) | Secondary CIDR blocks to attach to the VPC | `list(string)` | `[]` | no |
+| <a name="input_secondary_cidr_blocks"></a> [secondary\_cidr\_blocks](#input\_secondary\_cidr\_blocks) | Secondary CIDR blocks to attach to the VPC | `list(string)` | `[]` | no |
 | <a name="input_shim"></a> [shim](#input\_shim) | If true will not create the network and forward the input values to the same outputs. | `bool` | `false` | no |
 | <a name="input_single_nat_gateway"></a> [single\_nat\_gateway](#input\_single\_nat\_gateway) | Single NAT Gateway, shared for all AZ and subnets | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | AWS Tags common to all the resources created | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Truefoundry AWS Network Module
 | Name | Description |
 |------|-------------|
 | <a name="output_availability_zones"></a> [availability\_zones](#output\_availability\_zones) | List of availability zones for VPC |
-| <a name="output_eks_pod_subnet_ids"></a> [eks\_pod\_subnet\_ids](#output\_eks\_pod\_subnet\_ids) | List of pod subnet IDs for EKS custom networking (from secondary CIDR) |
+| <a name="output_custom_networking_subnet_ids"></a> [custom\_networking\_subnet\_ids](#output\_custom\_networking\_subnet\_ids) | List of custom networking subnet IDs (from secondary CIDR) |
 | <a name="output_private_subnets_cidrs"></a> [private\_subnets\_cidrs](#output\_private\_subnets\_cidrs) | List of private subnet CIDRs in the VPC |
 | <a name="output_private_subnets_id"></a> [private\_subnets\_id](#output\_private\_subnets\_id) | List of private subnet IDs in the VPC |
 | <a name="output_public_subnets_cidrs"></a> [public\_subnets\_cidrs](#output\_public\_subnets\_cidrs) | List of public subnet CIDRs in the VPC |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Truefoundry AWS Network Module
 
 | Name | Type |
 |------|------|
+| [aws_route_table_association.custom_networking_eks_pods](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_subnet.custom_networking_eks_pods](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_iam_policy_document.flow_logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_subnet.private_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
@@ -40,6 +42,7 @@ Truefoundry AWS Network Module
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | VPC region | `string` | n/a | yes |
 | <a name="input_azs"></a> [azs](#input\_azs) | Availability Zones | `list(string)` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | AWS EKS cluster name needed for Shared cluster | `string` | `""` | no |
+| <a name="input_eks_pod_secondary_subnet_cidrs"></a> [eks\_pod\_secondary\_subnet\_cidrs](#input\_eks\_pod\_secondary\_subnet\_cidrs) | List of CIDR blocks for EKS pod subnets (one per AZ) from the secondary CIDR | `list(string)` | `[]` | no |
 | <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | Enable NAT Gateway - This is necessary for the cluster to work | `bool` | `true` | no |
 | <a name="input_external_nat_ip_ids"></a> [external\_nat\_ip\_ids](#input\_external\_nat\_ip\_ids) | External NAT IPs IDs | `list(string)` | `[]` | no |
 | <a name="input_flow_logs_bucket_attach_deny_insecure_transport_policy"></a> [flow\_logs\_bucket\_attach\_deny\_insecure\_transport\_policy](#input\_flow\_logs\_bucket\_attach\_deny\_insecure\_transport\_policy) | Flag to attach deny insecure transport policy to the bucket | `bool` | `true` | no |
@@ -57,12 +60,14 @@ Truefoundry AWS Network Module
 | <a name="input_flow_logs_bucket_restrict_public_buckets"></a> [flow\_logs\_bucket\_restrict\_public\_buckets](#input\_flow\_logs\_bucket\_restrict\_public\_buckets) | Flag to restrict public buckets on the bucket | `bool` | `true` | no |
 | <a name="input_flow_logs_enable"></a> [flow\_logs\_enable](#input\_flow\_logs\_enable) | Enable VPC flow logs | `bool` | `false` | no |
 | <a name="input_one_nat_gateway_per_az"></a> [one\_nat\_gateway\_per\_az](#input\_one\_nat\_gateway\_per\_az) | One NAT Gateway for each AZ. | `bool` | `false` | no |
+| <a name="input_pod_subnets_ids"></a> [pod\_subnets\_ids](#input\_pod\_subnets\_ids) | SHIM: Pre-existing pod subnet IDs for EKS custom networking | `list(string)` | `[]` | no |
 | <a name="input_private_subnet_extra_tags"></a> [private\_subnet\_extra\_tags](#input\_private\_subnet\_extra\_tags) | Extra tags for VPC private subnets | `map(string)` | `{}` | no |
 | <a name="input_private_subnets_cidrs"></a> [private\_subnets\_cidrs](#input\_private\_subnets\_cidrs) | Assigns IPv4 private subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | <a name="input_private_subnets_ids"></a> [private\_subnets\_ids](#input\_private\_subnets\_ids) | SHIM: Private Subnets IDs | `list(string)` | `[]` | no |
 | <a name="input_public_subnet_extra_tags"></a> [public\_subnet\_extra\_tags](#input\_public\_subnet\_extra\_tags) | Extra tags for VPC public subnets | `map(string)` | `{}` | no |
 | <a name="input_public_subnets_cidrs"></a> [public\_subnets\_cidrs](#input\_public\_subnets\_cidrs) | Assigns IPv4 public subnet id based on the Amazon provided /56 prefix base 10 integer (0-256). Must be of equal length to the corresponding IPv4 subnet list | `list(string)` | `[]` | no |
 | <a name="input_public_subnets_ids"></a> [public\_subnets\_ids](#input\_public\_subnets\_ids) | SHIM: Public Subnets IDs | `list(string)` | `[]` | no |
+| <a name="input_secondary_cidr_block"></a> [secondary\_cidr\_block](#input\_secondary\_cidr\_block) | Secondary CIDR blocks to attach to the VPC | `list(string)` | `[]` | no |
 | <a name="input_shim"></a> [shim](#input\_shim) | If true will not create the network and forward the input values to the same outputs. | `bool` | `false` | no |
 | <a name="input_single_nat_gateway"></a> [single\_nat\_gateway](#input\_single\_nat\_gateway) | Single NAT Gateway, shared for all AZ and subnets | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | AWS Tags common to all the resources created | `map(string)` | `{}` | no |
@@ -75,6 +80,7 @@ Truefoundry AWS Network Module
 | Name | Description |
 |------|-------------|
 | <a name="output_availability_zones"></a> [availability\_zones](#output\_availability\_zones) | List of availability zones for VPC |
+| <a name="output_eks_pod_subnet_ids"></a> [eks\_pod\_subnet\_ids](#output\_eks\_pod\_subnet\_ids) | List of pod subnet IDs for EKS custom networking (from secondary CIDR) |
 | <a name="output_private_subnets_cidrs"></a> [private\_subnets\_cidrs](#output\_private\_subnets\_cidrs) | List of private subnet CIDRs in the VPC |
 | <a name="output_private_subnets_id"></a> [private\_subnets\_id](#output\_private\_subnets\_id) | List of private subnet IDs in the VPC |
 | <a name="output_public_subnets_cidrs"></a> [public\_subnets\_cidrs](#output\_public\_subnets\_cidrs) | List of public subnet CIDRs in the VPC |

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Truefoundry AWS Network Module
 
 | Name | Type |
 |------|------|
-| [aws_route_table_association.custom_networking_eks_pods](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
-| [aws_subnet.custom_networking_eks_pods](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_route_table_association.custom_networking](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_subnet.custom_networking](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_iam_policy_document.flow_logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_subnet.private_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |

--- a/output.tf
+++ b/output.tf
@@ -28,7 +28,7 @@ output "public_subnets_cidrs" {
 
 output "custom_networking_subnet_ids" {
   description = "List of custom networking subnet IDs (from secondary CIDR)"
-  value       = var.shim && var.enable_custom_networking ? var.custom_networking_subnet_ids : aws_subnet.custom_networking_eks_pods[*].id
+  value       = var.shim && var.enable_custom_networking ? var.custom_networking_subnet_ids : aws_subnet.custom_networking[*].id
 }
 
 output "region" {

--- a/output.tf
+++ b/output.tf
@@ -26,6 +26,11 @@ output "public_subnets_cidrs" {
   value       = var.shim ? data.aws_subnet.public_subnets[*].cidr_block : var.public_subnets_cidrs
 }
 
+output "eks_pod_subnet_ids" {
+  description = "List of pod subnet IDs for EKS custom networking (from secondary CIDR)"
+  value       = var.shim ? var.pod_subnets_ids : aws_subnet.custom_networking_eks_pods[*].id
+}
+
 output "region" {
   description = "AWS region of VPC"
   value       = var.aws_region

--- a/output.tf
+++ b/output.tf
@@ -26,9 +26,9 @@ output "public_subnets_cidrs" {
   value       = var.shim ? data.aws_subnet.public_subnets[*].cidr_block : var.public_subnets_cidrs
 }
 
-output "eks_pod_subnet_ids" {
-  description = "List of pod subnet IDs for EKS custom networking (from secondary CIDR)"
-  value       = var.shim ? var.custom_networking_subnet_ids : aws_subnet.custom_networking_eks_pods[*].id
+output "custom_networking_subnet_ids" {
+  description = "List of custom networking subnet IDs (from secondary CIDR)"
+  value       = var.shim && var.enable_custom_networking ? var.custom_networking_subnet_ids : aws_subnet.custom_networking_eks_pods[*].id
 }
 
 output "region" {

--- a/output.tf
+++ b/output.tf
@@ -28,7 +28,7 @@ output "public_subnets_cidrs" {
 
 output "eks_pod_subnet_ids" {
   description = "List of pod subnet IDs for EKS custom networking (from secondary CIDR)"
-  value       = var.shim ? var.pod_subnets_ids : aws_subnet.custom_networking_eks_pods[*].id
+  value       = var.shim ? var.custom_networking_subnet_ids : aws_subnet.custom_networking_eks_pods[*].id
 }
 
 output "region" {

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,11 @@ variable "private_subnets_ids" {
   type        = list(string)
   default     = []
 }
+variable "pod_subnets_ids" {
+  description = "SHIM: Pre-existing pod subnet IDs for EKS custom networking"
+  type        = list(string)
+  default     = []
+}
 
 ##################################################################################
 ## NON-SHIM
@@ -78,6 +83,22 @@ variable "one_nat_gateway_per_az" {
   description = "One NAT Gateway for each AZ."
   default     = false
   type        = bool
+}
+
+##################################################################################
+## Pod Networking (EKS Custom CNI)
+##################################################################################
+
+variable "secondary_cidr_block" {
+  description = "Secondary CIDR blocks to attach to the VPC"
+  type        = list(string)
+  default     = []
+}
+
+variable "eks_pod_secondary_subnet_cidrs" {
+  description = "List of CIDR blocks for EKS pod subnets (one per AZ) from the secondary CIDR"
+  type        = list(string)
+  default     = []
 }
 
 ##################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "private_subnets_ids" {
   type        = list(string)
   default     = []
 }
-variable "pod_subnets_ids" {
+variable "custom_networking_subnet_ids" {
   description = "SHIM: Pre-existing pod subnet IDs for EKS custom networking"
   type        = list(string)
   default     = []
@@ -89,14 +89,20 @@ variable "one_nat_gateway_per_az" {
 ## Pod Networking (EKS Custom CNI)
 ##################################################################################
 
-variable "secondary_cidr_block" {
+variable "enable_custom_networking" {
+  description = "Enable custom networking"
+  type        = bool
+  default     = false
+}
+
+variable "secondary_cidr_blocks" {
   description = "Secondary CIDR blocks to attach to the VPC"
   type        = list(string)
   default     = []
 }
 
-variable "eks_pod_secondary_subnet_cidrs" {
-  description = "List of CIDR blocks for EKS pod subnets (one per AZ) from the secondary CIDR"
+variable "custom_networking_subnet_cidrs" {
+  description = "List of CIDR blocks for EKS custom networking subnets (one per AZ) from the secondary CIDR"
   type        = list(string)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,6 +46,11 @@ variable "public_subnets_cidrs" {
   type        = list(string)
   default     = []
 }
+variable "secondary_cidr_blocks" {
+  description = "Secondary CIDR blocks to attach to the VPC"
+  type        = list(string)
+  default     = []
+}
 variable "public_subnet_extra_tags" {
   type        = map(string)
   default     = {}
@@ -95,11 +100,6 @@ variable "enable_custom_networking" {
   default     = false
 }
 
-variable "secondary_cidr_blocks" {
-  description = "Secondary CIDR blocks to attach to the VPC"
-  type        = list(string)
-  default     = []
-}
 
 variable "custom_networking_subnet_cidrs" {
   description = "List of CIDR blocks for EKS custom networking subnets (one per AZ) from the secondary CIDR"

--- a/variables.tf
+++ b/variables.tf
@@ -105,11 +105,6 @@ variable "custom_networking_subnet_cidrs" {
   description = "List of CIDR blocks for EKS custom networking subnets (one per AZ) from the secondary CIDR"
   type        = list(string)
   default     = []
-
-  validation {
-    condition     = length(var.custom_networking_subnet_cidrs) <= length(var.azs)
-    error_message = "custom_networking_subnet_cidrs must not have more entries than azs. Got ${length(var.custom_networking_subnet_cidrs)} subnet CIDRs but only ${length(var.azs)} availability zones."
-  }
 }
 
 ##################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -105,6 +105,11 @@ variable "custom_networking_subnet_cidrs" {
   description = "List of CIDR blocks for EKS custom networking subnets (one per AZ) from the secondary CIDR"
   type        = list(string)
   default     = []
+
+  validation {
+    condition     = length(var.custom_networking_subnet_cidrs) <= length(var.azs)
+    error_message = "custom_networking_subnet_cidrs must not have more entries than azs. Got ${length(var.custom_networking_subnet_cidrs)} subnet CIDRs but only ${length(var.azs)} availability zones."
+  }
 }
 
 ##################################################################################

--- a/vpc.tf
+++ b/vpc.tf
@@ -28,6 +28,8 @@ module "aws-vpc-module" {
   flow_log_log_format       = "$${version} $${account-id} $${instance-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status} $${az-id} $${pkt-srcaddr} $${pkt-dstaddr} $${pkt-src-aws-service} $${pkt-dst-aws-service} $${flow-direction} $${traffic-path}"
   vpc_flow_log_tags         = local.tags
 
+  secondary_cidr_blocks = var.secondary_cidr_block
+
   public_subnet_tags = merge(
     {
       "kubernetes.io/cluster/${var.cluster_name}" = "shared"
@@ -56,4 +58,28 @@ resource "aws_vpc_endpoint" "s3" {
   vpc_id       = module.aws-vpc-module[0].vpc_id
   service_name = "com.amazonaws.${var.aws_region}.s3"
   tags         = local.tags
+}
+
+
+resource "aws_subnet" "custom_networking_eks_pods" {
+  count = var.shim == true || length(var.secondary_cidr_block) == 0 ? 0 : length(var.eks_pod_secondary_subnet_cidrs)
+
+  vpc_id            = module.aws-vpc-module[0].vpc_id
+  cidr_block        = var.eks_pod_secondary_subnet_cidrs[count.index]
+  availability_zone = var.azs[count.index]
+
+  tags = merge(local.tags, {
+    Name                               = "${var.cluster_name}-pod-${var.azs[count.index]}"
+    "custom_networking_eks_pod_subnet" = "1"
+    "subnet"                           = "private"
+  })
+
+  depends_on = [module.aws-vpc-module]
+}
+
+resource "aws_route_table_association" "custom_networking_eks_pods" {
+  count = var.shim == true || length(var.secondary_cidr_block) == 0 ? 0 : length(var.eks_pod_secondary_subnet_cidrs)
+
+  subnet_id      = aws_subnet.custom_networking_eks_pods[count.index].id
+  route_table_id = element(module.aws-vpc-module[0].private_route_table_ids, count.index)
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -67,6 +67,7 @@ resource "aws_subnet" "custom_networking_eks_pods" {
   vpc_id            = module.aws-vpc-module[0].vpc_id
   cidr_block        = var.custom_networking_subnet_cidrs[count.index]
   availability_zone = var.azs[count.index]
+  tags              = local.tags
 
   depends_on = [module.aws-vpc-module]
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -28,7 +28,7 @@ module "aws-vpc-module" {
   flow_log_log_format       = "$${version} $${account-id} $${instance-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status} $${az-id} $${pkt-srcaddr} $${pkt-dstaddr} $${pkt-src-aws-service} $${pkt-dst-aws-service} $${flow-direction} $${traffic-path}"
   vpc_flow_log_tags         = local.tags
 
-  secondary_cidr_blocks = var.secondary_cidr_block
+  secondary_cidr_blocks = var.enable_custom_networking ? var.secondary_cidr_blocks : []
 
   public_subnet_tags = merge(
     {
@@ -62,23 +62,17 @@ resource "aws_vpc_endpoint" "s3" {
 
 
 resource "aws_subnet" "custom_networking_eks_pods" {
-  count = var.shim == true || length(var.secondary_cidr_block) == 0 ? 0 : length(var.eks_pod_secondary_subnet_cidrs)
+  count = var.shim == false && var.enable_custom_networking == true ? length(var.custom_networking_subnet_cidrs) : 0
 
   vpc_id            = module.aws-vpc-module[0].vpc_id
-  cidr_block        = var.eks_pod_secondary_subnet_cidrs[count.index]
+  cidr_block        = var.custom_networking_subnet_cidrs[count.index]
   availability_zone = var.azs[count.index]
-
-  tags = merge(local.tags, {
-    Name                               = "${var.cluster_name}-pod-${var.azs[count.index]}"
-    "custom_networking_eks_pod_subnet" = "1"
-    "subnet"                           = "private"
-  })
 
   depends_on = [module.aws-vpc-module]
 }
 
 resource "aws_route_table_association" "custom_networking_eks_pods" {
-  count = var.shim == true || length(var.secondary_cidr_block) == 0 ? 0 : length(var.eks_pod_secondary_subnet_cidrs)
+  count = var.shim == false && var.enable_custom_networking == true ? length(var.custom_networking_subnet_cidrs) : 0
 
   subnet_id      = aws_subnet.custom_networking_eks_pods[count.index].id
   route_table_id = element(module.aws-vpc-module[0].private_route_table_ids, count.index)

--- a/vpc.tf
+++ b/vpc.tf
@@ -61,7 +61,7 @@ resource "aws_vpc_endpoint" "s3" {
 }
 
 
-resource "aws_subnet" "custom_networking_eks_pods" {
+resource "aws_subnet" "custom_networking" {
   count = var.shim == false && var.enable_custom_networking == true ? length(var.custom_networking_subnet_cidrs) : 0
 
   vpc_id            = module.aws-vpc-module[0].vpc_id
@@ -72,9 +72,9 @@ resource "aws_subnet" "custom_networking_eks_pods" {
   depends_on = [module.aws-vpc-module]
 }
 
-resource "aws_route_table_association" "custom_networking_eks_pods" {
+resource "aws_route_table_association" "custom_networking" {
   count = var.shim == false && var.enable_custom_networking == true ? length(var.custom_networking_subnet_cidrs) : 0
 
-  subnet_id      = aws_subnet.custom_networking_eks_pods[count.index].id
+  subnet_id      = aws_subnet.custom_networking[count.index].id
   route_table_id = element(module.aws-vpc-module[0].private_route_table_ids, count.index)
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -28,7 +28,7 @@ module "aws-vpc-module" {
   flow_log_log_format       = "$${version} $${account-id} $${instance-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status} $${az-id} $${pkt-srcaddr} $${pkt-dstaddr} $${pkt-src-aws-service} $${pkt-dst-aws-service} $${flow-direction} $${traffic-path}"
   vpc_flow_log_tags         = local.tags
 
-  secondary_cidr_blocks = var.secondary_cidr_blocks 
+  secondary_cidr_blocks = var.secondary_cidr_blocks
 
   public_subnet_tags = merge(
     {

--- a/vpc.tf
+++ b/vpc.tf
@@ -28,7 +28,7 @@ module "aws-vpc-module" {
   flow_log_log_format       = "$${version} $${account-id} $${instance-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status} $${az-id} $${pkt-srcaddr} $${pkt-dstaddr} $${pkt-src-aws-service} $${pkt-dst-aws-service} $${flow-direction} $${traffic-path}"
   vpc_flow_log_tags         = local.tags
 
-  secondary_cidr_blocks = var.enable_custom_networking ? var.secondary_cidr_blocks : []
+  secondary_cidr_blocks = var.secondary_cidr_blocks 
 
   public_subnet_tags = merge(
     {


### PR DESCRIPTION
# Changelog 

- Support for secondary CIDR allocation for VPC.
- Additional subnet creation using secondary CIDRs' and its route table association for EKS custom networking.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Terraform-managed VPC topology by attaching secondary CIDR blocks and optionally creating/associating additional subnets, which can affect routing and IP allocation. Default behavior is unchanged unless new flags/inputs are enabled.
> 
> **Overview**
> Adds optional support for attaching `secondary_cidr_blocks` to the VPC and enabling EKS custom networking via `enable_custom_networking`.
> 
> When enabled (non-shim), the module creates per-AZ `aws_subnet.custom_networking` from `custom_networking_subnet_cidrs` and associates them to the existing private route tables, and exposes their IDs via a new `custom_networking_subnet_ids` output (also supporting shim mode via `custom_networking_subnet_ids` input). Documentation (`README.md` TF docs) is updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2a4391ace663011081c2976763708c962c5192c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->